### PR TITLE
Update form_submit_bs4 label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.1.36] - 2020-04-23
+- fixed not default contao label used in 
+
 ## [1.1.35] - 2020-02-06
 - fixed useTwigTemplate checkbox not evaluated before applying logic
 - fixed dca issue in tl_layout

--- a/src/Resources/views/forms/form_submit_bs4.html.twig
+++ b/src/Resources/views/forms/form_submit_bs4.html.twig
@@ -2,6 +2,6 @@
 
 {% block field %}
 <button type="submit" id="ctrl_{{ strId }}" class="btn btn-primary {{ strClass }}" aria-label="{{ 'huh.twig.teplates.button.submit.aria-label'|trans }}" {{ attributes|default()|raw }}>
-    {% trans %}huh.twig.templates.label.submit{% endtrans %}
+    {% if arrConfiguration.slabel is defined and arrConfiguration.slabel is not empty %}{{ arrConfiguration.slabel }}{% else %}{% trans %}huh.twig.templates.label.submit{% endtrans %}{% endif %}
 </button>
 {% endblock %}


### PR DESCRIPTION
Update form submit label in bs4 template to the contao default variable instead of an custom translation.